### PR TITLE
Edit-message-model

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,5 +2,6 @@ class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
   validates :group_name, presence: true
+  has_many :messages
 end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :messages, only: [:index]
+    resources :messages, only: [:index, :create]
   end
 end
 

--- a/db/migrate/20190315040615_create_messages.rb
+++ b/db/migrate/20190315040615_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.string :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190313070339) do
+ActiveRecord::Schema.define(version: 20190315040615) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -25,6 +25,17 @@ ActiveRecord::Schema.define(version: 20190313070339) do
     t.string   "group_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "content"
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -43,4 +54,6 @@ ActiveRecord::Schema.define(version: 20190313070339) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
#what
Message-modelテーブル作成
メッセージを保存するルーティングとviewの表示のルーティング
group, user, messageモデルのアソシエーション
バリデーションでメッセージが空では送信不可、ただしイメージは除く
#WHY
メッセージ投稿機能実装のため